### PR TITLE
Update UrlGenerator.php - ::action() appending rootNamespace to fully qualified controller names

### DIFF
--- a/src/Illuminate/Routing/UrlGenerator.php
+++ b/src/Illuminate/Routing/UrlGenerator.php
@@ -521,7 +521,10 @@ class UrlGenerator implements UrlGeneratorContract {
 	 */
 	public function action($action, $parameters = array(), $absolute = true)
 	{
-		if ($this->rootNamespace && ! (strpos($action, '\\') === 0))
+		if ($this->rootNamespace && 
+			! (strpos($action, $this->rootNamespace) === 0) && 
+			! (strpos($action, '\\') === 0)
+		)
 		{
 			$action = $this->rootNamespace.'\\'.$action;
 		}


### PR DESCRIPTION
`action('App/Http/Controllers/SomeController@getMyAction')` appends rootNamespace from UrlGenerator when the action name is fully qualified

If this is intended, please disregard this pull request!

I use get_called_class() and Route::currentActionName() a fair amount.  Both of these return the FQN of the controller.  When that gets sent into action('...'), UrlGenerator::action appends the rootNamespace onto the already fully qualified namespace.  I thought it might be as simple as added a third check to see if the rootNamespace is the beginning of the action parameter.
